### PR TITLE
Add test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Thumbs.db
 /.vscode
 .phpunit.result.cache
 composer.lock
+/build

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,4 +20,15 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="tap" target="build/report.tap"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
 </phpunit>


### PR DESCRIPTION
This PR adds modifies the configuration of PHPUnit to put coverage information to the `build` folder of the project.