### PR TITLE
Identifier should be only used when necessary

### DIFF
--- a/src/ChunkUploaderServiceProvider.php
+++ b/src/ChunkUploaderServiceProvider.php
@@ -52,12 +52,10 @@ class ChunkUploaderServiceProvider extends ServiceProvider
         $this->app->singleton(UploadHandler::class, function () {
             /** @var \Illuminate\Support\Manager $uploadManager */
             $uploadManager = $this->app['chunk-uploader.upload-manager'];
-            /** @var \Illuminate\Support\Manager $identityManager */
-            $identityManager = $this->app['chunk-uploader.identity-manager'];
 
             $storageConfig = new StorageConfig($this->app->make('config')->get('chunk-uploader'));
 
-            return new UploadHandler($uploadManager->driver(), $identityManager->driver(), $storageConfig);
+            return new UploadHandler($uploadManager->driver(), $storageConfig);
         });
     }
 

--- a/src/Driver/DropzoneUploadDriver.php
+++ b/src/Driver/DropzoneUploadDriver.php
@@ -33,10 +33,10 @@ class DropzoneUploadDriver extends UploadDriver
     /**
      * {@inheritDoc}
      */
-    public function handle(Request $request, Identifier $identifier, StorageConfig $config, Closure $fileUploaded = null): Response
+    public function handle(Request $request, StorageConfig $config, Closure $fileUploaded = null): Response
     {
         if ($this->isRequestMethodIn($request, [Request::METHOD_POST])) {
-            return $this->save($request, $identifier, $config, $fileUploaded);
+            return $this->save($request, $config, $fileUploaded);
         }
 
         throw new MethodNotAllowedHttpException([
@@ -52,7 +52,7 @@ class DropzoneUploadDriver extends UploadDriver
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function save(Request $request, Identifier $identifier, StorageConfig $config, Closure $fileUploaded = null): Response
+    public function save(Request $request, StorageConfig $config, Closure $fileUploaded = null): Response
     {
         $file = $request->file($this->fileParam);
 
@@ -65,7 +65,7 @@ class DropzoneUploadDriver extends UploadDriver
         }
 
         if ($this->isMonolithRequest($request)) {
-            return $this->saveMonolith($file, $identifier, $config, $fileUploaded);
+            return $this->saveMonolith($file, $config, $fileUploaded);
         }
 
         $this->validateChunkRequest($request);
@@ -111,11 +111,9 @@ class DropzoneUploadDriver extends UploadDriver
      *
      * @return Response
      */
-    private function saveMonolith(UploadedFile $file, Identifier $identifier, StorageConfig $config, Closure $fileUploaded = null): Response
+    private function saveMonolith(UploadedFile $file, StorageConfig $config, Closure $fileUploaded = null): Response
     {
-        $filename = $identifier->generateUploadedFileIdentifierName($file);
-
-        $path = $file->storeAs($config->getMergedDirectory(), $filename, [
+        $path = $file->store($config->getMergedDirectory(), [
             'disk' => $config->getDisk(),
         ]);
 

--- a/src/Driver/MonolithUploadDriver.php
+++ b/src/Driver/MonolithUploadDriver.php
@@ -27,10 +27,10 @@ class MonolithUploadDriver extends UploadDriver
     /**
      * {@inheritDoc}
      */
-    public function handle(Request $request, Identifier $identifier, StorageConfig $config, Closure $fileUploaded = null): Response
+    public function handle(Request $request, StorageConfig $config, Closure $fileUploaded = null): Response
     {
         if ($request->isMethod(Request::METHOD_POST)) {
-            return $this->save($request, $identifier, $config, $fileUploaded);
+            return $this->save($request, $config, $fileUploaded);
         }
 
         if ($request->isMethod(Request::METHOD_GET)) {
@@ -41,7 +41,11 @@ class MonolithUploadDriver extends UploadDriver
             return $this->delete($request, $config);
         }
 
-        throw new MethodNotAllowedHttpException([Request::METHOD_POST, Request::METHOD_GET, Request::METHOD_DELETE]);
+        throw new MethodNotAllowedHttpException([
+            Request::METHOD_POST,
+            Request::METHOD_GET,
+            Request::METHOD_DELETE,
+        ]);
     }
 
     /**
@@ -52,7 +56,7 @@ class MonolithUploadDriver extends UploadDriver
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function save(Request $request, Identifier $identifier, StorageConfig $config, Closure $fileUploaded = null): Response
+    public function save(Request $request, StorageConfig $config, Closure $fileUploaded = null): Response
     {
         $file = $request->file($this->fileParam);
 
@@ -60,9 +64,7 @@ class MonolithUploadDriver extends UploadDriver
             throw new UploadHttpException($file->getErrorMessage());
         }
 
-        $filename = $identifier->generateUploadedFileIdentifierName($file);
-
-        $path = $file->storeAs($config->getMergedDirectory(), $filename, [
+        $path = $file->store($config->getMergedDirectory(), [
             'disk' => $config->getDisk(),
         ]);
 

--- a/src/Driver/UploadDriver.php
+++ b/src/Driver/UploadDriver.php
@@ -6,7 +6,6 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use LaraCrafts\ChunkUploader\Event\FileUploaded;
-use LaraCrafts\ChunkUploader\Identifier\Identifier;
 use LaraCrafts\ChunkUploader\StorageConfig;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -17,14 +16,13 @@ abstract class UploadDriver
 
     /**
      * @param \Illuminate\Http\Request $request
-     * @param Identifier $identifier
      * @param StorageConfig $config
      * @param \Closure|null $fileUploaded
      *
      * @return \Symfony\Component\HttpFoundation\Response
      *
      */
-    abstract public function handle(Request $request, Identifier $identifier, StorageConfig $config, Closure $fileUploaded = null): Response;
+    abstract public function handle(Request $request, StorageConfig $config, Closure $fileUploaded = null): Response;
 
     /**
      * @param string $filename

--- a/src/UploadHandler.php
+++ b/src/UploadHandler.php
@@ -6,7 +6,6 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Traits\Macroable;
 use LaraCrafts\ChunkUploader\Driver\UploadDriver;
-use LaraCrafts\ChunkUploader\Identifier\Identifier;
 use Symfony\Component\HttpFoundation\Response;
 
 class UploadHandler
@@ -24,35 +23,27 @@ class UploadHandler
     protected $config;
 
     /**
-     * @var \LaraCrafts\ChunkUploader\Identifier\Identifier
-     */
-    protected $identifier;
-
-    /**
      * UploadHandler constructor.
      *
      * @param \LaraCrafts\ChunkUploader\Driver\UploadDriver $driver
-     * @param \LaraCrafts\ChunkUploader\Identifier\Identifier $identifier
      * @param StorageConfig $config
      */
-    public function __construct(UploadDriver $driver, Identifier $identifier, StorageConfig $config)
+    public function __construct(UploadDriver $driver, StorageConfig $config)
     {
         $this->driver = $driver;
         $this->config = $config;
-        $this->identifier = $identifier;
     }
 
     /**
      * Save an uploaded file to the target directory.
      *
      * @param \Illuminate\Http\Request $request
-     *
      * @param \Closure $fileUploaded
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response|\Symfony\Component\HttpFoundation\Response
      */
     public function handle(Request $request, Closure $fileUploaded = null): Response
     {
-        return $this->driver->handle($request, $this->identifier, $this->config, $fileUploaded);
+        return $this->driver->handle($request, $this->config, $fileUploaded);
     }
 }

--- a/src/UploadManager.php
+++ b/src/UploadManager.php
@@ -16,7 +16,10 @@ class UploadManager extends Manager
 
     public function createBlueimpDriver()
     {
-        return new BlueimpUploadDriver($this->app['config']['chunk-uploader.blueimp']);
+        /** @var \Illuminate\Support\Manager $identityManager */
+        $identityManager = $this->app['chunk-uploader.identity-manager'];
+
+        return new BlueimpUploadDriver($this->app['config']['chunk-uploader.blueimp'], $identityManager->driver());
     }
 
     public function createDropzoneDriver()

--- a/tests/Driver/DropzoneUploadDriverTest.php
+++ b/tests/Driver/DropzoneUploadDriverTest.php
@@ -5,7 +5,6 @@ namespace LaraCrafts\ChunkUploader\Tests\Driver;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
 use LaraCrafts\ChunkUploader\Driver\DropzoneUploadDriver;
@@ -67,44 +66,40 @@ class DropzoneUploadDriverTest extends TestCase
 
     public function testUploadMonolith()
     {
-        Session::shouldReceive('getId')
-            ->andReturn('frgYt7cPmNGtORpRCo4xvFIrWklzFqc2mnO6EE6b');
-
+        $file = UploadedFile::fake()->create('test.txt', 100);
         $request = Request::create('', Request::METHOD_POST, [], [], [
-            'file' => UploadedFile::fake()->create('test.txt', 100),
+            'file' => $file,
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse|\LaraCrafts\ChunkUploader\Response\Response $response */
+        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 100]);
 
-        Storage::disk('local')->assertExists('merged/2494cefe4d234bd331aeb4514fe97d810efba29b.txt');
+        Storage::disk('local')->assertExists($file->hashName('merged'));
 
-        Event::assertDispatched(FileUploaded::class, function ($event) {
-            return $event->file = 'merged/2494cefe4d234bd331aeb4514fe97d810efba29b.txt';
+        Event::assertDispatched(FileUploaded::class, function ($event) use ($file) {
+            return $event->file = $file->hashName('merged');
         });
     }
 
     public function testUploadMonolithWithCallback()
     {
-        Session::shouldReceive('getId')
-            ->andReturn('frgYt7cPmNGtORpRCo4xvFIrWklzFqc2mnO6EE6b');
-
+        $file = UploadedFile::fake()->create('test.txt', 100);
         $request = Request::create('', Request::METHOD_POST, [], [], [
-            'file' => UploadedFile::fake()->create('test.txt', 100),
+            'file' => $file,
         ]);
 
         $callback = $this->createClosureMock(
             $this->once(),
             'local',
-            'merged/2494cefe4d234bd331aeb4514fe97d810efba29b.txt'
+            $file->hashName('merged')
         );
 
         $this->handler->handle($request, $callback);
 
-        Event::assertDispatched(FileUploaded::class, function ($event) {
-            return $event->file = 'merged/2494cefe4d234bd331aeb4514fe97d810efba29b.txt';
+        Event::assertDispatched(FileUploaded::class, function ($event) use ($file) {
+            return $event->file = $file->hashName('merged');
         });
     }
 
@@ -158,7 +153,7 @@ class DropzoneUploadDriverTest extends TestCase
             'file' => UploadedFile::fake()->create('test.txt', 100),
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse|\LaraCrafts\ChunkUploader\Response\Response $response */
+        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 50]);
@@ -207,7 +202,7 @@ class DropzoneUploadDriverTest extends TestCase
             'file' => UploadedFile::fake()->create('test.txt', 100),
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse|\LaraCrafts\ChunkUploader\Response\Response $response */
+        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 100]);

--- a/tests/Identifier/SessionIdentifierTest.php
+++ b/tests/Identifier/SessionIdentifierTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace LaraCrafts\ChunkUploader\Tests\Identifier;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Session;
+use LaraCrafts\ChunkUploader\Identifier\SessionIdentifier;
+use Orchestra\Testbench\TestCase;
+
+class SessionIdentifierTest extends TestCase
+{
+    /**
+     * @var \LaraCrafts\ChunkUploader\Identifier\SessionIdentifier
+     */
+    private $identifier;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        Session::shouldReceive('getId')
+            ->andReturn('frgYt7cPmNGtORpRCo4xvFIrWklzFqc2mnO6EE6b');
+
+        $this->identifier = new SessionIdentifier();
+    }
+
+    public function testGenerateIdentifier()
+    {
+        $identifier = $this->identifier->generateIdentifier('test.txt');
+        $this->assertEquals('2494cefe4d234bd331aeb4514fe97d810efba29b', $identifier);
+    }
+
+    public function testGenerateIdentifierWithoutExtension()
+    {
+        $identifier = $this->identifier->generateIdentifier('test');
+        $this->assertEquals('3b7b99bf70a98a544319cf3bad9e912e1b89984d', $identifier);
+    }
+
+    public function testUploadedFileIdentifierName()
+    {
+        $file = UploadedFile::fake()->create('test.txt', 100);
+        $identifier = $this->identifier->generateUploadedFileIdentifierName($file);
+        $this->assertEquals('2494cefe4d234bd331aeb4514fe97d810efba29b.txt', $identifier);
+    }
+
+    public function testUploadedFileIdentifierNameWithoutExtension()
+    {
+        $file = UploadedFile::fake()->create('test', 100);
+        $identifier = $this->identifier->generateUploadedFileIdentifierName($file);
+        $this->assertEquals('3b7b99bf70a98a544319cf3bad9e912e1b89984d', $identifier);
+    }
+}


### PR DESCRIPTION
This PR removes the `Identifier` dependency from the constructor of `UploadHandler` as well as from the `handle` method of `UploadDriver`. The `Identifier` should be only used when the library does not provide an identifier for the uploaded file. In case of `MonolithUploadDriver` a random identifier can be used as the final filename.

Also test for `SessionIdentifier`.