### PR TITLE
Force download

### DIFF
--- a/src/Driver/UploadDriver.php
+++ b/src/Driver/UploadDriver.php
@@ -10,6 +10,7 @@ use LaraCrafts\ChunkUploader\Identifier\Identifier;
 use LaraCrafts\ChunkUploader\StorageConfig;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 abstract class UploadDriver
@@ -44,7 +45,7 @@ abstract class UploadDriver
 
         $path = $disk->path($prefix . $filename);
 
-        return new BinaryFileResponse($path);
+        return new BinaryFileResponse($path, 200, [], true, ResponseHeaderBag::DISPOSITION_ATTACHMENT);
     }
 
     public function isRequestMethodIn(Request $request, array $methods): bool

--- a/tests/Driver/BlueimpUploadDriverTest.php
+++ b/tests/Driver/BlueimpUploadDriverTest.php
@@ -12,6 +12,7 @@ use LaraCrafts\ChunkUploader\Event\FileUploaded;
 use LaraCrafts\ChunkUploader\Tests\TestCase;
 use LaraCrafts\ChunkUploader\UploadHandler;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class BlueimpUploadDriverTest extends TestCase
 {
@@ -63,6 +64,8 @@ class BlueimpUploadDriverTest extends TestCase
         /** @var \Illuminate\Foundation\Testing\TestResponse|\Symfony\Component\HttpFoundation\BinaryFileResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Disposition', 'attachment; filename="local-test-file"');
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response->baseResponse);
         $this->assertEquals('local-test-file', $response->getFile()->getFilename());

--- a/tests/Driver/BlueimpUploadDriverTest.php
+++ b/tests/Driver/BlueimpUploadDriverTest.php
@@ -64,8 +64,8 @@ class BlueimpUploadDriverTest extends TestCase
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertStatus(200);
-        $response->assertHeader('Content-Disposition', 'attachment; filename="local-test-file"');
 
+        $this->assertContains('attachment', $response->headers->get('Content-Disposition'));
         $this->assertInstanceOf(BinaryFileResponse::class, $response->baseResponse);
         $this->assertEquals('local-test-file', $response->getFile()->getFilename());
     }

--- a/tests/Driver/BlueimpUploadDriverTest.php
+++ b/tests/Driver/BlueimpUploadDriverTest.php
@@ -12,7 +12,6 @@ use LaraCrafts\ChunkUploader\Event\FileUploaded;
 use LaraCrafts\ChunkUploader\Tests\TestCase;
 use LaraCrafts\ChunkUploader\UploadHandler;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class BlueimpUploadDriverTest extends TestCase
 {

--- a/tests/Driver/MonolithUploadDriverTest.php
+++ b/tests/Driver/MonolithUploadDriverTest.php
@@ -12,6 +12,7 @@ use LaraCrafts\ChunkUploader\Event\FileUploaded;
 use LaraCrafts\ChunkUploader\Tests\TestCase;
 use LaraCrafts\ChunkUploader\UploadHandler;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class MonolithUploadDriverTest extends TestCase
 {
@@ -47,6 +48,8 @@ class MonolithUploadDriverTest extends TestCase
         /** @var \Illuminate\Foundation\Testing\TestResponse|\Symfony\Component\HttpFoundation\BinaryFileResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Disposition', 'attachment; filename="local-test-file"');
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response->baseResponse);
         $this->assertEquals('local-test-file', $response->getFile()->getFilename());

--- a/tests/Driver/MonolithUploadDriverTest.php
+++ b/tests/Driver/MonolithUploadDriverTest.php
@@ -12,7 +12,6 @@ use LaraCrafts\ChunkUploader\Event\FileUploaded;
 use LaraCrafts\ChunkUploader\Tests\TestCase;
 use LaraCrafts\ChunkUploader\UploadHandler;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class MonolithUploadDriverTest extends TestCase
 {

--- a/tests/Driver/MonolithUploadDriverTest.php
+++ b/tests/Driver/MonolithUploadDriverTest.php
@@ -48,8 +48,8 @@ class MonolithUploadDriverTest extends TestCase
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertStatus(200);
-        $response->assertHeader('Content-Disposition', 'attachment; filename="local-test-file"');
 
+        $this->assertContains('attachment', $response->headers->get('Content-Disposition'));
         $this->assertInstanceOf(BinaryFileResponse::class, $response->baseResponse);
         $this->assertEquals('local-test-file', $response->getFile()->getFilename());
     }


### PR DESCRIPTION
This PR adds `Content-Disposition` header with `attachment` value to download requests.

Read more about `Content-Disposition` [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition).