### PR TITLE
Support for laravel 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,27 +5,24 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
 
 env:
-  - ILLUMINATE_VERSION=5.5.* TESTBENCH_VERSION=3.5.* PHPUNIT_VERSION=^6.0
-  - ILLUMINATE_VERSION=5.6.* TESTBENCH_VERSION=3.6.* PHPUNIT_VERSION=^7.0
-  - ILLUMINATE_VERSION=5.7.* TESTBENCH_VERSION=3.7.* PHPUNIT_VERSION=^7.0
+  - ILLUMINATE_VERSION=5.5.*
+  - ILLUMINATE_VERSION=5.7.*
+  - ILLUMINATE_VERSION=5.6.*
+  - ILLUMINATE_VERSION=5.8.*
+  - ILLUMINATE_VERSION=^6.0
 
-matrix:    # Laravel 5.6 & 5.7 do not support PHP7.0
+matrix:    # Laravel 6.0 does not support PHP 7.1
   exclude:
-    - php: 7.0
-      env: ILLUMINATE_VERSION=5.6.* TESTBENCH_VERSION=3.6.* PHPUNIT_VERSION=^7.0
-    - php: 7.0
-      env: ILLUMINATE_VERSION=5.7.* TESTBENCH_VERSION=3.7.* PHPUNIT_VERSION=^7.0
+    - php: 7.1
+      env: ILLUMINATE_VERSION=^6.0
 
 before_install:
   - composer require illuminate/support:${ILLUMINATE_VERSION} illuminate/http:${ILLUMINATE_VERSION} --no-update
-  - composer require orchestra/testbench:${TESTBENCH_VERSION} --no-update
-  - composer require phpunit/phpunit:${PHPUNIT_VERSION} --no-update
 
 install:
   - composer install --no-interaction --no-progress --no-suggest --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^3.5 || ^4.0",
-        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.3",
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",
         "mockery/mockery": "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/http": "^5.5 || ^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.5 || 4.0",
+        "orchestra/testbench": "^3.5 || ^4.0",
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.3",
         "mockery/mockery": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,13 @@
         }
     ],
     "require": {
-        "php": "^7.0",
-        "laravel/framework": "^5.5"
+        "php": "^7.1",
+        "illuminate/support": "^5.5 || ^6.0",
+        "illuminate/http": "^5.5 || ^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "3.5.*",
-        "phpunit/phpunit": "^6.0 || ^7.0",
+        "orchestra/testbench": "^3.5 || 4.0",
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.3",
         "mockery/mockery": "^1.0"
     },
     "autoload": {

--- a/tests/Driver/BlueimpUploadDriverTest.php
+++ b/tests/Driver/BlueimpUploadDriverTest.php
@@ -20,7 +20,7 @@ class BlueimpUploadDriverTest extends TestCase
      */
     private $handler;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Driver/BlueimpUploadDriverTest.php
+++ b/tests/Driver/BlueimpUploadDriverTest.php
@@ -11,6 +11,7 @@ use LaraCrafts\ChunkUploader\Driver\BlueimpUploadDriver;
 use LaraCrafts\ChunkUploader\Event\FileUploaded;
 use LaraCrafts\ChunkUploader\Tests\TestCase;
 use LaraCrafts\ChunkUploader\UploadHandler;
+use PHPUnit\Framework\Constraint\StringContains;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class BlueimpUploadDriverTest extends TestCase
@@ -65,7 +66,7 @@ class BlueimpUploadDriverTest extends TestCase
         $response->assertSuccessful();
         $response->assertStatus(200);
 
-        $this->assertContains('attachment', $response->headers->get('Content-Disposition'));
+        $this->assertThat($response->headers->get('Content-Disposition'), new StringContains('attachment'));
         $this->assertInstanceOf(BinaryFileResponse::class, $response->baseResponse);
         $this->assertEquals('local-test-file', $response->getFile()->getFilename());
     }

--- a/tests/Driver/DropzoneUploadDriverTest.php
+++ b/tests/Driver/DropzoneUploadDriverTest.php
@@ -21,7 +21,7 @@ class DropzoneUploadDriverTest extends TestCase
      */
     private $handler;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Driver/MonolithUploadDriverTest.php
+++ b/tests/Driver/MonolithUploadDriverTest.php
@@ -10,6 +10,7 @@ use LaraCrafts\ChunkUploader\Driver\MonolithUploadDriver;
 use LaraCrafts\ChunkUploader\Event\FileUploaded;
 use LaraCrafts\ChunkUploader\Tests\TestCase;
 use LaraCrafts\ChunkUploader\UploadHandler;
+use PHPUnit\Framework\Constraint\StringContains;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class MonolithUploadDriverTest extends TestCase
@@ -48,7 +49,7 @@ class MonolithUploadDriverTest extends TestCase
         $response->assertSuccessful();
         $response->assertStatus(200);
 
-        $this->assertContains('attachment', $response->headers->get('Content-Disposition'));
+        $this->assertThat($response->headers->get('Content-Disposition'), new StringContains('attachment'));
         $this->assertInstanceOf(BinaryFileResponse::class, $response->baseResponse);
         $this->assertEquals('local-test-file', $response->getFile()->getFilename());
     }

--- a/tests/Driver/MonolithUploadDriverTest.php
+++ b/tests/Driver/MonolithUploadDriverTest.php
@@ -19,7 +19,7 @@ class MonolithUploadDriverTest extends TestCase
      */
     private $handler;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Identifier/SessionIdentifierTest.php
+++ b/tests/Identifier/SessionIdentifierTest.php
@@ -14,7 +14,7 @@ class SessionIdentifierTest extends TestCase
      */
     private $identifier;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UploadManagerTest.php
+++ b/tests/UploadManagerTest.php
@@ -17,7 +17,7 @@ class UploadManagerTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
This resolves #24

PHP 7.0 support was removed.
Laravel 5.8 and 6.0 support was added.