### PR TITLE
Fix identical operator by casting parameters in RequestBodyRange

### DIFF
--- a/src/Range/RequestBodyRange.php
+++ b/src/Range/RequestBodyRange.php
@@ -30,10 +30,11 @@ class RequestBodyRange implements Range
             $request = $request->request;
         }
 
-        $this->index = $request->get($indexKey);
-        $this->numberOfChunks = $request->get($numberOfChunksKey);
-        $this->chunkSize = $request->get($chunkSizeKey);
-        $this->totalSize = $request->get($totalSizeKey);
+        $this->index = (int) $request->get($indexKey);
+        $this->numberOfChunks = (int) $request->get($numberOfChunksKey);
+        $this->chunkSize = (int) $request->get($chunkSizeKey);
+        // Must be double (which is an alias for float) for 32 bit systems
+        $this->totalSize = (double) $request->get($totalSizeKey);
 
         if ($this->numberOfChunks <= 0) {
             throw new InvalidArgumentException(sprintf('`%s` must be greater than zero', $numberOfChunksKey));

--- a/tests/Range/RequestBodyRangeTest.php
+++ b/tests/Range/RequestBodyRangeTest.php
@@ -135,10 +135,10 @@ class RequestBodyRangeTest extends TestCase
     private function createRequestBodyRange($index, $numberOfChunks, $chunkSize, $totalSize)
     {
         $request = new ParameterBag([
-            'index' => $index,
-            'numberOfChunks' => $numberOfChunks,
-            'chunkSize' => $chunkSize,
-            'totalSize' => $totalSize,
+            'index' => (string) $index,
+            'numberOfChunks' => (string) $numberOfChunks,
+            'chunkSize' => (string) $chunkSize,
+            'totalSize' => (string) $totalSize,
         ]);
 
         return new RequestBodyRange($request, 'index', 'numberOfChunks', 'chunkSize', 'totalSize');


### PR DESCRIPTION
Parameters from a request are strings but the identical operator (`===`) will compare it with an `int` or a `float` which will always return `false`.

This PR fixes this issue by casting the strings to the proper type.